### PR TITLE
Update nightmare_zone.simba

### DIFF
--- a/nightmare_zone.simba
+++ b/nightmare_zone.simba
@@ -418,13 +418,13 @@ begin
   if not Self.HasBoostPot then
     Exit;
 
-  if BoostTimer.IsFinished() and not PotStr.Contains('Overload') then
-    Boosted := False;
-
   if PotStr.Contains('Overload') then
-    Result := (Minimap.GetHPLevel > 50)
-  else
-    Result := not Boosted;
+    Exit(Minimap.GetHPLevel() > 50);
+
+  if BoostTimer.IsFinished() then
+    Self.Boosted := False;
+  
+  Result := not Boosted;
 end;
 
 function TNMZFighter.GetAbsorptionPoints(): Int32;

--- a/nightmare_zone.simba
+++ b/nightmare_zone.simba
@@ -418,7 +418,7 @@ begin
   if not Self.HasBoostPot then
     Exit;
 
-  if BoostTimer.IsFinished() then
+  if BoostTimer.IsFinished() and not PotStr.Contains('Overload') then
     Boosted := False;
 
   if PotStr.Contains('Overload') then

--- a/nightmare_zone.simba
+++ b/nightmare_zone.simba
@@ -419,12 +419,11 @@ begin
     Exit;
 
   if PotStr.Contains('Overload') then
-    Exit(Minimap.GetHPLevel() > 50);
-
-  if BoostTimer.IsFinished() then
+    Self.Boosted := Minimap.GetHPLevel() <= 50
+  else if BoostTimer.IsFinished() then
     Self.Boosted := False;
   
-  Result := not Boosted;
+  Result := not Self.Boosted;
 end;
 
 function TNMZFighter.GetAbsorptionPoints(): Int32;


### PR DESCRIPTION
Boost timer only accurate for potions +-59 seconds so will only be right some times. 