### PR TITLE
fix(nightmare_zone): fix not drinking overload

### DIFF
--- a/wasp_nightmare_zone.simba
+++ b/wasp_nightmare_zone.simba
@@ -485,6 +485,8 @@ begin
 
   while Self.NeedLowerHP(currentHP) do
   begin
+    if (Self.Potion = 'Overload') and Self.HasBoostPot() and (currentHP > 50) then
+      Exit;                
     Inventory.ClickSlot(slot, slotOption);
     Wait(100);
 


### PR DESCRIPTION
I believe the bug with the NMZ script skipping Overload potions is caused by the lower HP while loop.  As it's lowering HP, the Overload effect expires but the script will continue to lower the HP past the 51 HP threshold thus preventing further usage of the Overload potion.

My suggested fix for this issue is to check the following while trying to lower HP:
- The user is using Overloads
- The user has Overloads
- The user is above 50 HP