### PR TITLE
Wasp Blast Furnace Desync and Glove fixes

### DIFF
--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -695,7 +695,7 @@ begin
         if Inventory.ContainsRandomItems(Self.ItemList) then
           Exit(EBFState.DEPOSIT_RANDOM_ITEMS);
 
-        if Self.HasGloves and not Inventory.ContainsAny([Self.GoldGloves, Self.IceGloves]) then
+        if Bank.ContainsAny([Self.GoldGloves, Self.IceGloves]) and (CurrentBar = EBarType.GOLD) and not Inventory.ContainsAny([Self.GoldGloves, Self.IceGloves]) then
           Exit(EBFState.WITHDRAW_GLOVES);
 
         if UseCoalBag and not Inventory.ContainsItem(Self.CoalBag) then

--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -300,7 +300,7 @@ end;
 function TBlastFurnace.WaitXP(): Boolean;
 begin
   Self.PotFull := False;
-  Result := XPBar.WaitXP(12000); // Conveyor stops randomly as part of minigame. Script will get out of sync if we don't give conveyor enough time to restart and give XP for the already deposited ores.
+  Result := XPBar.WaitXP(8000);
   if Result then
   begin
     Self.DispenserFull := True;
@@ -456,7 +456,7 @@ begin
     if not Self.DispenserFull then
       Self.DispenserFull := XPBar.EarnedXP();
 
-    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) and Inventory.ContainsItem('Gold Ore') then // Makes so script equips gold gloves again after inventory is full of gold ore. Script would click bank > equip gloves > have to click bank again if we don't do this.
+    if changeGloves and Inventory.ContainsAll([Self.GoldGloves, 'Gold Ore']) then
     begin
       if not MainScreen.HasInterface() and Inventory.ClickItem(Self.GoldGloves) then
       begin
@@ -520,13 +520,17 @@ end;
 
 
 function TBlastFurnace.EquipIceGloves(): Boolean;
+var
+  slot: Int32;
 begin
-  Result := Inventory.ClickItem(Self.IceGloves);
-  Wait(1000); // Small wait to reduce occurance of multiple click changing to wrong gloves
+  Result := Inventory.FindItem(Self.IceGloves, slot) and
+            Inventory.ClickSlot(slot);
+
   if not Result then
     Exit;
 
-  RSObjects.BlastFurnaceBarDispenser.Hover();
+  if WaitUntil(not Inventory.IsSlotUsed(slot), 300, 2400) then
+    RSObjects.BlastFurnaceBarDispenser.Hover();
 end;
 
 function TBlastFurnace.EnableRun(): Boolean;
@@ -695,7 +699,7 @@ begin
         if Inventory.ContainsRandomItems(Self.ItemList) then
           Exit(EBFState.DEPOSIT_RANDOM_ITEMS);
 
-        if Bank.ContainsAny([Self.GoldGloves, Self.IceGloves]) and (CurrentBar = EBarType.GOLD) and not Inventory.ContainsAny([Self.GoldGloves, Self.IceGloves]) then
+        if Self.HasGloves and not Inventory.ContainsAny([Self.GoldGloves, Self.IceGloves]) then
           Exit(EBFState.WITHDRAW_GLOVES);
 
         if UseCoalBag and not Inventory.ContainsItem(Self.CoalBag) then

--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -14,8 +14,8 @@ type
   );
 
 var
-  CurrentBar: EBarType = EBarType.MITHRIL;
-  UseCoalBag: Boolean = True;
+  CurrentBar: EBarType = EBarType.GOLD;
+  UseCoalBag: Boolean = False;
   UseEnergyBoosts: Boolean = False;
 
 type
@@ -300,7 +300,7 @@ end;
 function TBlastFurnace.WaitXP(): Boolean;
 begin
   Self.PotFull := False;
-  Result := XPBar.WaitXP(600);
+  Result := XPBar.WaitXP(12000); // Conveyor stops randomly as part of minigame. Script will get out of sync if we don't give conveyor enough time to restart and give XP for the already deposited ores.
   if Result then
   begin
     Self.DispenserFull := True;
@@ -456,7 +456,7 @@ begin
     if not Self.DispenserFull then
       Self.DispenserFull := XPBar.EarnedXP();
 
-    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) then
+    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) and Inventory.ContainsItem('Gold Ore') then // Makes so script equips gold gloves again after inventory is full of gold ore. Script would click bank > equip gloves > have to click bank again if we don't do this.
     begin
       if not MainScreen.HasInterface() and Inventory.ClickItem(Self.GoldGloves) then
       begin
@@ -522,7 +522,7 @@ end;
 function TBlastFurnace.EquipIceGloves(): Boolean;
 begin
   Result := Inventory.ClickItem(Self.IceGloves);
-
+  Wait(1000); // Small wait to reduce occurance of multiple click changing to wrong gloves
   if not Result then
     Exit;
 

--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -1,5 +1,5 @@
 {$DEFINE SCRIPT_ID := 'a17eeda7-b3e7-4aba-9d9a-cc2d338e41ba'}
-{$DEFINE SCRIPT_REVISION := '6'}
+{$DEFINE SCRIPT_REVISION := '7'}
 {$DEFINE SCRIPT_GUI}
 {$I SRL-T/osr.simba}
 {$I WaspLib/osr.simba}
@@ -14,8 +14,8 @@ type
   );
 
 var
-  CurrentBar: EBarType = EBarType.MITHRIL;
-  UseCoalBag: Boolean = True;
+  CurrentBar: EBarType = EBarType.GOLD;
+  UseCoalBag: Boolean = False;
   UseEnergyBoosts: Boolean = False;
 
 type
@@ -300,7 +300,7 @@ end;
 function TBlastFurnace.WaitXP(): Boolean;
 begin
   Self.PotFull := False;
-  Result := XPBar.WaitXP(600);
+  Result := XPBar.WaitXP(12000); // Conveyor stops randomly as part of minigame. Script will get out of sync if we don't give conveyor enough time to restart and give XP for the already deposited ores.
   if Result then
   begin
     Self.DispenserFull := True;
@@ -456,7 +456,7 @@ begin
     if not Self.DispenserFull then
       Self.DispenserFull := XPBar.EarnedXP();
 
-    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) then
+    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) and Inventory.ContainsItem('Gold Ore') then // Makes so script equips gold gloves again after inventory is full of gold ore. Script would click bank > equip gloves > have to click bank again if we don't do this.
     begin
       if not MainScreen.HasInterface() and Inventory.ClickItem(Self.GoldGloves) then
       begin
@@ -522,7 +522,7 @@ end;
 function TBlastFurnace.EquipIceGloves(): Boolean;
 begin
   Result := Inventory.ClickItem(Self.IceGloves);
-
+  Wait(1000); // Small wait to reduce occurance of multiple click changing to wrong gloves
   if not Result then
     Exit;
 

--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -14,8 +14,8 @@ type
   );
 
 var
-  CurrentBar: EBarType = EBarType.GOLD;
-  UseCoalBag: Boolean = False;
+  CurrentBar: EBarType = EBarType.MITHRIL;
+  UseCoalBag: Boolean = True;
   UseEnergyBoosts: Boolean = False;
 
 type
@@ -300,7 +300,7 @@ end;
 function TBlastFurnace.WaitXP(): Boolean;
 begin
   Self.PotFull := False;
-  Result := XPBar.WaitXP(12000); // Conveyor stops randomly as part of minigame. Script will get out of sync if we don't give conveyor enough time to restart and give XP for the already deposited ores.
+  Result := XPBar.WaitXP(600);
   if Result then
   begin
     Self.DispenserFull := True;
@@ -456,7 +456,7 @@ begin
     if not Self.DispenserFull then
       Self.DispenserFull := XPBar.EarnedXP();
 
-    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) and Inventory.ContainsItem('Gold Ore') then // Makes so script equips gold gloves again after inventory is full of gold ore. Script would click bank > equip gloves > have to click bank again if we don't do this.
+    if changeGloves and Inventory.ContainsItem(Self.GoldGloves) then
     begin
       if not MainScreen.HasInterface() and Inventory.ClickItem(Self.GoldGloves) then
       begin
@@ -522,7 +522,7 @@ end;
 function TBlastFurnace.EquipIceGloves(): Boolean;
 begin
   Result := Inventory.ClickItem(Self.IceGloves);
-  Wait(1000); // Small wait to reduce occurance of multiple click changing to wrong gloves
+
   if not Result then
     Exit;
 


### PR DESCRIPTION
These changes address a couple of issues:
1. As part of the blast furnace minigame, the conveyor will randomly stop. The script was not waiting enough time on XPBar.WaitXP for the conveyor to restart and XP get added to the bar. This should address this issue and in testing, did not get out of sync in 5000 gold bars, and gold was where this issue was mainly happening.
2. When doing gold bars, the script would do : get-bars>click bank>equip goldsmith gauntlets>click bank again (as equipping interrupted first bank click). Now, it will do : get-bars>click bank>withdraw gold ore>equip goldsmith gloves
3. Sometimes the script would click multiple times on ice gloves causing it to switch back to goldsmith. Added a small wait to help mitigate.
4. Will now deposit/withdraw goldsmith gauntlets when necessary.

Tested these changes by making a few hundred of each bar type and they completed successfully.