### PR TITLE
CutTree Fix

### DIFF
--- a/wasp_woodcutter.simba
+++ b/wasp_woodcutter.simba
@@ -234,22 +234,57 @@ begin
   end;
 end;
 
+function TCuboidExArray.ToBoxArray() : TBoxArray;
+var
+  cuboid : TCuboidEx;
+  i : Int32;
+begin
+  SetLength(Result, Length(Self));
+  for i to High(Self) do
+  begin
+    Result[i] := Self[i].Bounds();
+  end;
+end;
 
 function TWoodcutter.CutTree(): Boolean;
 var
-  i: Int32;
+  Trees: T2DPointArray;
+  iterItem : TPointArray;
+  searchBox : TBox;
+  MScuboids : TCuboidExArray;
+  cuboidBoxArr : TBoxArray;
+
 begin
-  Result := RSTree.WalkClick();
-  if Result then
+   MScuboids := Self.RSW.GetCuboidArrayMS(Self.RSW.GetMyPos(), Self.RSTree.Coordinates, Self.RSTree.ShapeArray, [-2, 0]);
+  cuboidBoxArr := MScuboids.ToBoxArray();
+  cuboidBoxArr.SortFromMidPoint(MainScreen.GetPlayerBox.Middle);
+
+  for searchBox in cuboidBoxArr do
   begin
-    for i := 0 to High(Self.TreeCuboids) do
-      if Self.TreeCuboids[i].Bounds().Contains(Mouse.Position) then
-        Self.TreeWalkerCoord := Self.RSW.MSToWorld(Self.TreeCuboids[i].Bottom.Mean(), 0);
-    Minimap.WaitMoving();
-    XPBar.EarnedXP();
-    Self.Woodcutting := True;
-    Self.TreeTimer.Restart();
-    Wait(2400, 3200);
+    Trees := MainScreen.FindObject(Self.RSTree.Finder, searchBox);
+    if Trees.Len() > 0 then
+      break;
+  end;
+
+  if Trees.Len() < 1 then
+  begin
+    Minimap.SetCompassAngle(Minimap.GetCompassAngle() + Random(-50, 50), 10);
+    Exit;
+  end;
+
+  for iterItem in Trees do
+  begin
+    Mouse.Move(iterItem.Median);
+    if MainScreen.IsUpText(Self.RSTree.UpText) then
+    begin
+      Mouse.Click(MOUSE_LEFT);
+      Minimap.WaitMoving();
+      Self.TreeWalkerCoord := Self.RSW.MSToWorld(Mouse.Position(), Round(Self.RSTree.ShapeArray[0].Tile.Z/2));
+      Result := True;
+      XPBar.EarnedXP();
+      Self.Woodcutting := True;
+      Self.TreeTimer.Restart();
+    end;
   end;
 end;
 


### PR DESCRIPTION
Current implementation gets stuck because it's just checking if the mouse is in the bounds of where a tree might be. It's not searching for a new tree. This older implementation we did works better because it gets those same cuboids but it actually colour searches in them to find a new tree to go to. This way it shouldn't get stuck on one tree.