### PR TITLE
fix(pickpocketer): HVA should be greater than zero

### DIFF
--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -599,7 +599,7 @@ begin
   Result := Bank.DepositRandomItems(Self.StackableArray);
   if ItemCount > 0 then
   begin
-    if Inventory.CountItem(ValuableItem) = 0 then
+    if Inventory.CountItem(ValuableItem) > 0 then
       TotalProfit += (ItemCount * ValuableItemValue);
   end;
 end;


### PR DESCRIPTION
High Value Items are not properly being added to the total profit because it is checking "equal zero" when it should be "greater than zero"