### PR TITLE
fix(pickpocketer): totalProfit and withdraw fix

### DIFF
--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -535,6 +535,11 @@ begin
   FreshNeck := HasNeck := Result;
 end;
 
+function TThiever.WithdrawNecks(): Boolean;
+begin
+  if Result := Bank.WithdrawItem([Necklace, NeckAmount - Inventory.CountItem(Necklace), False], False) then Wait(300, 400);
+end;
+
 function TThiever.CheckNeck(): Boolean;
 begin
   Result := HasNeck := Equipment.ContainsItem(Necklace);
@@ -771,7 +776,7 @@ begin
       OPEN_BANK: Bank.WalkOpen();
       DEPOSIT_LOOT: Self.Deposit();
       WITHDRAW_FOOD: Bank.WithdrawConsumable(ERSConsumable.FOOD);
-      WITHDRAW_NECKLACES: Bank.WithdrawItem([Necklace, NeckAmount, False], False);
+      WITHDRAW_NECKLACES: Self.WithdrawNecks();
       CLOSE_INTERFACE: MainScreen.CloseInterface();
 
       OPEN_CHAT: ChatButtons.Open(ERSChatButton.GAME_CHAT);

--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -599,7 +599,7 @@ begin
   Result := Bank.DepositRandomItems(Self.StackableArray);
   if ItemCount > 0 then
   begin
-    if Inventory.CountItem(ValuableItem) = 0 then
+    if Inventory.CountItem(ValuableItem) > 0 then
       TotalProfit += (ItemCount * ValuableItemValue);
   end;
 end;

--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -504,7 +504,7 @@ begin
   begin
     Self.CoinPouchLimit := SRL.TruncatedGauss(28 * DiaryLevel, 1);
     Self.TotalActions += pouchCount;
-    Self.TotalProfit := Self.TotalActions * Self.ActionProfit;
+    Self.TotalProfit += pouchCount * Self.ActionProfit;
     WL.Activity.Restart();
   end;
 end;

--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -771,7 +771,7 @@ begin
       OPEN_BANK: Bank.WalkOpen();
       DEPOSIT_LOOT: Self.Deposit();
       WITHDRAW_FOOD: Bank.WithdrawConsumable(ERSConsumable.FOOD);
-      WITHDRAW_NECKLACES: Self.Withdraw([Necklace, NeckAmount, False]);
+      WITHDRAW_NECKLACES: Bank.WithdrawItem([Necklace, NeckAmount, False], False);
       CLOSE_INTERFACE: MainScreen.CloseInterface();
 
       OPEN_CHAT: ChatButtons.Open(ERSChatButton.GAME_CHAT);

--- a/wasp_pickpocketer.simba
+++ b/wasp_pickpocketer.simba
@@ -537,7 +537,7 @@ end;
 
 function TThiever.WithdrawNecks(): Boolean;
 begin
-  if Result := Bank.WithdrawItem([Necklace, NeckAmount - Inventory.CountItem(Necklace), False], False) then Wait(300, 400);
+  if Result := Bank.WithdrawItem([Necklace, NeckAmount - Inventory.CountItem(Necklace), False], False) then Wait(1000, 1400);
 end;
 
 function TThiever.CheckNeck(): Boolean;


### PR DESCRIPTION
High Value Items are not properly being added to the total profit because it is checking "equal zero" when it should be "greater than zero"