### PR TITLE
Update wasp_blast_furnace.simba

### DIFF
--- a/wasp_blast_furnace.simba
+++ b/wasp_blast_furnace.simba
@@ -472,7 +472,7 @@ var
   p: TPoint;
   tpa: TPointArray;
 begin
-  tpa := PopulateTile(Self.DispenserCoordinate, 2);
+  tpa := PopulateTile(Self.DispenserCoordinate, 1);
   tpa.Remove(Self.DispenserCoordinate);
   p := Self.RSW.WorldToMM(tpa.RandomValue());
 


### PR DESCRIPTION
This stops the x 644 y 113 out of bounds bug that is currently plaguing help chat by tightening up the rectangle for populate tile.