### PR TITLE
fix: crystal shards -> crystal shard

### DIFF
--- a/wasp_woodcutter.simba
+++ b/wasp_woodcutter.simba
@@ -186,7 +186,7 @@ begin
   Self.BankList += 'Clue nest (medium)';
   Self.BankList += 'Clue nest (hard)';
   Self.BankList += 'Clue nest (elite)';
-  Self.BankList += 'Crystal shards';
+  Self.BankList += 'Crystal shard';
 end;
 
 procedure TWoodcutter.SetupBank();


### PR DESCRIPTION
Remove typo, fixes banking of crystal shards

https://oldschool.runescape.wiki/w/Crystal_shard